### PR TITLE
fhore/classname using reduce + getColor refactor

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,10 +14,7 @@ const tailwind = classNames =>  classNames.split(' ').reduce((currentStyles, cla
 	}, {});
 
 // Pass the name of a color (e.g. "blue-500") and receive a color value (e.g. "#4399e1")
-const getColor = name => {
-	const obj = tailwind(`bg-${name}`);
-	return obj.backgroundColor;
-};
+const getColor = name => tailwind(`bg-${name}`).backgroundColor;
 
 module.exports = tailwind;
 module.exports.default = tailwind;

--- a/index.js
+++ b/index.js
@@ -4,19 +4,14 @@ const styles = require('./styles.json');
 // Pass a list of class names separated by a space, for example:
 // "bg-green-100 text-green-800 font-semibold")
 // and receive a styles object for use in React Native views
-const tailwind = classNames => {
-	const obj = {};
-
-	for (const className of classNames.split(' ')) {
+const tailwind = classNames =>  classNames.split(' ').reduce((currentStyles, className ) => {
 		if (styles[className]) {
-			Object.assign(obj, styles[className]);
+			return { ...currentStyles, ...styles[className] };
 		} else {
 			console.warn(`Unsupported Tailwind class: "${className}"`);
+			return currentStyles;
 		}
-	}
-
-	return obj;
-};
+	}, {});
 
 // Pass the name of a color (e.g. "blue-500") and receive a color value (e.g. "#4399e1")
 const getColor = name => {

--- a/index.js
+++ b/index.js
@@ -5,12 +5,11 @@ const styles = require('./styles.json');
 // "bg-green-100 text-green-800 font-semibold")
 // and receive a styles object for use in React Native views
 const tailwind = classNames => classNames.split(' ').reduce((currentStyles, className) => {
-	if (styles[className]) {
-		return {...currentStyles, ...styles[className]};
-	} else {
+	if (!styles[className]) {
 		console.warn(`Unsupported Tailwind class: "${className}"`);
-		return currentStyles;
 	}
+
+	return {...currentStyles, ...styles[className]};
 }, {});
 
 // Pass the name of a color (e.g. "blue-500") and receive a color value (e.g. "#4399e1")

--- a/index.js
+++ b/index.js
@@ -4,14 +4,14 @@ const styles = require('./styles.json');
 // Pass a list of class names separated by a space, for example:
 // "bg-green-100 text-green-800 font-semibold")
 // and receive a styles object for use in React Native views
-const tailwind = classNames =>  classNames.split(' ').reduce((currentStyles, className ) => {
-		if (styles[className]) {
-			return { ...currentStyles, ...styles[className] };
-		} else {
-			console.warn(`Unsupported Tailwind class: "${className}"`);
-			return currentStyles;
-		}
-	}, {});
+const tailwind = classNames => classNames.split(' ').reduce((currentStyles, className) => {
+	if (styles[className]) {
+		return {...currentStyles, ...styles[className]};
+	} else {
+		console.warn(`Unsupported Tailwind class: "${className}"`);
+		return currentStyles;
+	}
+}, {});
 
 // Pass the name of a color (e.g. "blue-500") and receive a color value (e.g. "#4399e1")
 const getColor = name => tailwind(`bg-${name}`).backgroundColor;


### PR DESCRIPTION
This PR refactor the `tailwind` function to use a `reduce` instead of a `for` statment, changing this to a simpler function. 

Also, i changed the `getColor` to get the `backgroundColor` directly instead of calling first  the `tailwind`, and then returning. About that, i think adding something like:

```
const getColor = name => tailwind(`bg-${name}`).backgroundColor || throw Error("Unknown property");
```

would be interesting. 😃 