### PR TITLE
Return empty object when no class names are passed

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,10 @@ const styles = require('./styles.json');
 const tailwind = classNames => {
 	const obj = {};
 
+	if (!classNames) {
+		return obj;
+	}
+
 	for (const className of classNames.split(' ')) {
 		if (styles[className]) {
 			Object.assign(obj, styles[className]);

--- a/test.js
+++ b/test.js
@@ -19,3 +19,10 @@ test('ignore unknown classes', t => {
 test('get color value', t => {
 	t.is(getColor('blue-500'), '#4299e1');
 });
+
+test('ignore no value param', t => {
+	t.deepEqual(tailwind(null), {});
+	t.deepEqual(tailwind(false), {});
+	t.deepEqual(tailwind(undefined), {});
+	t.deepEqual(tailwind(0), {});
+});


### PR DESCRIPTION
To support cases like this:

`tailwind(checkSomeVar && 'text-green-500')`

