### PR TITLE
Fix example code in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ $ npm install tailwind-rn
 Import `tailwind-rn` module and use any of the [supported utilities](#supported-utilities) from [Tailwind CSS](https://tailwindcss.com) in your [React Native](https://reactnative.dev) views.
 
 ```js
-import {SafeAreaView, View} from 'react-native';
+import {SafeAreaView, View, Text} from 'react-native';
 import tailwind from 'tailwind-rn';
 
 const App = () => (


### PR DESCRIPTION
`Text` is not imported in the example.

This PR fixes it.