### PR TITLE
currentColor and css property fixes

### DIFF
--- a/build.js
+++ b/build.js
@@ -82,7 +82,8 @@ const supportedUtilities = [
 	// Background color
 	/^bg-(transparent|black|white|gray|red|orange|yellow|green|teal|blue|indigo|purple|pink)/,
 	// Border color, style, width, radius
-	/^(border|rounded)/,
+	/^border-(?!current)/,
+	/^rounded/,
 	// Opacity
 	/^opacity-/,
 	// Pointer events

--- a/build.js
+++ b/build.js
@@ -11,26 +11,36 @@ const {stylesheet} = css.parse(source);
 
 const remToPx = value => `${parseFloat(value) * 16}px`;
 
-const getStyles = rule => {
-	const styles = rule.declarations
-		.filter(({property}) => {
-			// Skip line-height utilities without units
-			if (property === 'line-height') {
-				return false;
-			}
+const getStyles = (rule) => {
+  const styles = rule.declarations
+    .filter(({ property, value }) => {
+      // skip usage of vars I don't think they do anything
+      if (value.includes("var(")) {
+        return false
+      }
 
-			return true;
-		})
-		.map(({property, value}) => {
-			if (value.endsWith('rem')) {
-				return [property, remToPx(value)];
-			}
+      // remove var properties
+      if (property.includes('--')) {
+        return false
+      }
 
-			return [property, value];
-		});
+      // Skip line-height utilities without units
+      if (property === 'line-height') {
+        return false
+      }
 
-	return cssToReactNative(styles);
-};
+      return true
+    })
+    .map(({ property, value }) => {
+      if (value.endsWith('rem')) {
+        return [property, remToPx(value)]
+      }
+
+      return [property, value]
+    })
+
+  return cssToReactNative(styles)
+}
 
 const supportedUtilities = [
 	// Flexbox


### PR DESCRIPTION
I'm pretty sure the latest versions of tailwind aren't compatible with this package. For example, the backgroundColor values generated reference css custom properties which don't appear to work, and currentColor values break the conversion to react native styles. This should fix both of those issues, albeit a little messy. 