### PR TITLE
Fixed custom background color.

### DIFF
--- a/build.js
+++ b/build.js
@@ -72,10 +72,8 @@ const supportedUtilities = [
 	'lowercase',
 	'capitalize',
 	'normal-case',
-	// Background color
-	/^bg-(transparent|black|white|gray|red|orange|yellow|green|teal|blue|indigo|purple|pink)/,
-	// Background opacity
-	/^bg-opacity-/,
+	// Background color, opacity
+	/^bg-(?!fixed|local|scroll|bottom|center|left|left-.+|left-top|right|right-.+|top|repeat|repeat-.+|no-repeat|auto|cover|contain).+/,
 	// Border color, style, width, radius, opacity
 	/^(border|rounded)/,
 	// Opacity

--- a/build.js
+++ b/build.js
@@ -73,7 +73,7 @@ const supportedUtilities = [
 	'capitalize',
 	'normal-case',
 	// Background color, opacity
-	/^bg-(?!fixed|local|scroll|bottom|center|left|left-.+|left-top|right|right-.+|top|repeat|repeat-.+|no-repeat|auto|cover|contain).+/,
+	/^bg-(?!fixed|local|scroll|bottom|center|left|left-.+|left-top|right|right-.+|top|repeat|repeat-.+|no-repeat|auto|cover|contain)/,
 	// Border color, style, width, radius, opacity
 	/^(border|rounded)/,
 	// Opacity


### PR DESCRIPTION
`bg-custom-color` is being removed from `styles.json`. Doing this with `/^bg-/` is kind of good but we should really exclude the other options. I agree with the comment that this is an ugly regex.
I guess
`/^bg-(?!fixed|local|scroll|opacity-.+|bottom|center|left|left-.+|left-top|right|right-.+|top|repeat|repeat-.+|no-repeat|auto|cover|contain)/`
will work for both color and utility class.