### PR TITLE
Support full customization

### DIFF
--- a/build.js
+++ b/build.js
@@ -25,7 +25,7 @@ const getStyles = rule => {
 	return cssToReactNative(styles);
 };
 
-const unsupportedProperties = [
+const unsupportedProperties = new Set([
 	'box-sizing',
 	'float',
 	'clear',
@@ -89,7 +89,7 @@ const unsupportedProperties = [
 	'fill',
 	'stroke',
 	'stroke-width'
-];
+]);
 
 const isUtilitySupported = (utility, rule) => {
 	// Skip utilities with pseudo-selectors
@@ -106,15 +106,15 @@ const isUtilitySupported = (utility, rule) => {
 			'sr-only',
 			'not-sr-only'
 		].includes(utility) ||
-		/^(space|placeholder|from|via|to|divide)\-/.test(utility) ||
-		/^\-?(scale|rotate|translate|skew)\-/.test(utility)
+		/^(space|placeholder|from|via|to|divide)-/.test(utility) ||
+		/^-?(scale|rotate|translate|skew)-/.test(utility)
 	) {
 		return false;
 	}
 
 	// Skip utilities with unsupported properties
 	for (const {property, value} of rule.declarations) {
-		if (unsupportedProperties.includes(property)) {
+		if (unsupportedProperties.has(property)) {
 			return false;
 		}
 

--- a/build.js
+++ b/build.js
@@ -122,7 +122,10 @@ const isUtilitySupported = (utility, rule) => {
 			return false;
 		}
 
-		if (property === 'overflow' && !['visible', 'hidden'].includes(value)) {
+		if (
+			property === 'overflow' &&
+			!['visible', 'hidden', 'scroll'].includes(value)
+		) {
 			return false;
 		}
 

--- a/cli.js
+++ b/cli.js
@@ -12,7 +12,6 @@ meow(`
 `);
 
 const source = `
-@tailwind base;
 @tailwind components;
 @tailwind utilities;
 `;


### PR DESCRIPTION
This PR rewrites how `tailwind-rn` works. Previously it specified an allow list of utilities (classes), which would strip out any custom properties from your config, like custom colors. This PR changes it to block unsupported utilities and CSS properties instead, while allowing everything else.