### PR TITLE
Update PostCSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"css-to-react-native": "^3.0.0",
 		"match-all": "^1.2.6",
 		"meow": "^7.0.1",
-		"postcss": "^7.0.30"
+		"postcss": "^8.1.14"
 	},
 	"devDependencies": {
 		"@ava/babel": "^1.0.1",


### PR DESCRIPTION
PostCSS 8 was released and is used by newer versions of Tailwind, this library currently doesn't work with the latest version of Tailwind because of different PostCSS versions.