### PR TITLE
Apply singleton pattern to avoid wrapping.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,3 +6,4 @@ export function create(
 	tailwind: (classNames: string) => {[key: string]: string};
 	getColor: (color: string) => string;
 };
+export function setStyles(styles: object): void;

--- a/index.js
+++ b/index.js
@@ -96,11 +96,15 @@ const getColor = name => {
 	return style.backgroundColor;
 };
 
-const create = injectedTailwindStyles => {
+const setStyles = injectedTailwindStyles => {
 	// Pass a list of class names separated by a space, for example:
 	// "bg-green-100 text-green-800 font-semibold")
 	// and receive a styles object for use in React Native views
 	tailwindStyles = injectedTailwindStyles;
+};
+
+const create = injectedTailwindStyles => {
+	setStyles(injectedTailwindStyles);
 
 	return {tailwind, getColor};
 };
@@ -111,4 +115,4 @@ module.exports = tailwind;
 module.exports.default = tailwind;
 module.exports.getColor = getColor;
 module.exports.create = create;
-module.exports.setStyles = create;
+module.exports.setStyles = setStyles;

--- a/index.js
+++ b/index.js
@@ -61,50 +61,54 @@ const addLetterSpacing = (tailwindStyles, style, classNames) => {
 	style.letterSpacing = Number.parseFloat(letterSpacing) * fontSize;
 };
 
-const create = tailwindStyles => {
+let tailwindStyles;
+const tailwind = classNames => {
+	const style = {};
+
+	if (!classNames) {
+		return style;
+	}
+
+	addFontVariant(style, classNames);
+	addLetterSpacing(tailwindStyles, style, classNames);
+
+	const separateClassNames = classNames
+		.replace(/\s+/g, ' ')
+		.trim()
+		.split(' ')
+		.filter(className => !className.startsWith('tracking-'));
+
+	for (const className of separateClassNames) {
+		if (tailwindStyles[className]) {
+			Object.assign(style, tailwindStyles[className]);
+		} else {
+			console.warn(`Unsupported Tailwind class: "${className}"`);
+		}
+	}
+
+	return useVariables(style);
+};
+
+// Pass the name of a color (e.g. "blue-500") and receive a color value (e.g. "#4399e1"),
+// or a color and opacity (e.g. "black opacity-50") and get a color with opacity (e.g. "rgba(0,0,0,0.5)")
+const getColor = name => {
+	const style = tailwind(name.split(' ').map(className => `bg-${className}`).join(' '));
+	return style.backgroundColor;
+};
+
+const create = injectedTailwindStyles => {
 	// Pass a list of class names separated by a space, for example:
 	// "bg-green-100 text-green-800 font-semibold")
 	// and receive a styles object for use in React Native views
-	const tailwind = classNames => {
-		const style = {};
-
-		if (!classNames) {
-			return style;
-		}
-
-		addFontVariant(style, classNames);
-		addLetterSpacing(tailwindStyles, style, classNames);
-
-		const separateClassNames = classNames
-			.replace(/\s+/g, ' ')
-			.trim()
-			.split(' ')
-			.filter(className => !className.startsWith('tracking-'));
-
-		for (const className of separateClassNames) {
-			if (tailwindStyles[className]) {
-				Object.assign(style, tailwindStyles[className]);
-			} else {
-				console.warn(`Unsupported Tailwind class: "${className}"`);
-			}
-		}
-
-		return useVariables(style);
-	};
-
-	// Pass the name of a color (e.g. "blue-500") and receive a color value (e.g. "#4399e1"),
-	// or a color and opacity (e.g. "black opacity-50") and get a color with opacity (e.g. "rgba(0,0,0,0.5)")
-	const getColor = name => {
-		const style = tailwind(name.split(' ').map(className => `bg-${className}`).join(' '));
-		return style.backgroundColor;
-	};
+	tailwindStyles = injectedTailwindStyles;
 
 	return {tailwind, getColor};
 };
 
-const {tailwind, getColor} = create(require('./styles.json'));
+create(require('./styles.json'));
 
 module.exports = tailwind;
 module.exports.default = tailwind;
 module.exports.getColor = getColor;
 module.exports.create = create;
+module.exports.setStyles = create;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,8 +1,9 @@
 import {expectType} from 'tsd';
-import tailwind, {getColor, create} from '.';
+import tailwind, {getColor, create, setStyles} from '.';
 
 expectType<{[key: string]: string}>(tailwind('bg-blue-200'));
 expectType<string>(getColor('blue-200'));
 expectType<{[key: string]: string}>(create({}).tailwind('bg-blue-200'));
 expectType<string>(create({}).getColor('blue-200'));
 expectType<string>(create({}).getColor('blue-200 opacity-50'));
+expectType<void>(setStyles({}));

--- a/readme.md
+++ b/readme.md
@@ -138,42 +138,20 @@ Add this file to your version control system, because it's going to be needed wh
 $ npx create-tailwind-rn
 ```
 
-#### 3. Create a custom `tailwind()` function
+#### 3. Apply custom styles to `tailwind()` function
 
-Use `create()` function to generate the same `tailwind()` and `getColor()` functions, but with your custom styles applied.
+Use `setStyles()` function to applu your custom styles.
 
 ```js
-import {create} from 'tailwind-rn';
+import {setStyles} from 'tailwind-rn';
 import styles from './styles.json';
 
-const {tailwind, getColor} = create(styles);
-
+setStyles(styles);
 tailwind('text-blue-500 text-opacity-50');
 //=> {color: 'rgba(66, 153, 225, 0.5)'}
 ```
 
-Initializing `tailwind-rn` like that in every file you use it is not convenient.
-I'd recommend creating a `tailwind.js` file where you do it once and import it everywhere instead:
-
-**tailwind.js**
-
-```js
-import {create} from 'tailwind-rn';
-import styles from './styles.json';
-
-const {tailwind, getColor} = create(styles);
-export {tailwind, getColor};
-```
-
-You could also create an [alias](https://medium.com/@sterlingcobb/adding-alias-to-create-react-native-app-crna-in-2-minutes-45574f4a7729) for that file, so that you could import it using an absolute path from anywhere in your project:
-
-```js
-// Before
-import {tailwind} from '../../../tailwind';
-
-// After
-import {tailwind} from 'tailwind';
-```
+`tailwind-rn` is written with singleton pattern. Once you invoke `setStyles`, `tailwind` function will be affected to all of your workspace. Better call `setStyles` once in your application.
 
 ## API
 

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import tailwind, {getColor} from '.';
+import tailwind, {getColor, setStyles} from '.';
 
 test('get styles for one class', t => {
 	t.deepEqual(tailwind('text-blue-500'), {color: 'rgba(59, 130, 246, 1)'});
@@ -143,4 +143,19 @@ test('support letter spacing', t => {
 		letterSpacing: 1.6,
 		lineHeight: 24
 	});
+});
+
+test('tailwind function is singleton', t => {
+	const before = tailwind('bg-black');
+
+	setStyles({
+		'bg-black': {
+			'--tw-bg-opacity': 1,
+			backgroundColor: 'rgba(255, 255, 255, var(--tw-bg-opacity))'
+		}
+	});
+
+	const after = tailwind('bg-black');
+	t.notDeepEqual(before, after);
+	t.deepEqual(after, tailwind('bg-black'));
 });


### PR DESCRIPTION
The PR applies singleton pattern to `tailwind()` and `getColor()`.

`create()` has changed but still works as before for backward compatibility. 
IMHO It'd be better to replace with `setStyles()`. 
Returning new object with `create()` will be confusing with code editor's auto import features.

I had actually changed a lot of codes to support original `create()` function and support singleton at the same time.
But it gave a lot of confusion in terms of code readability and also to users. It, of course, made singleton meaningless as well.
So instead of rewriting with a lot of change, most of codes remain untouched except tailwindStyles as global variable.

Hope you guys like it.