### PR TITLE
Custom input/output file for cli

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,10 +1,16 @@
 #!/usr/bin/env node
 'use strict';
 const fs = require('fs');
+const path = require('path');
 const meow = require('meow');
 const postcss = require('postcss');
 const tailwind = require('tailwindcss');
 const build = require('./build');
+const yargs = require('yargs/yargs');
+const {hideBin} = require('yargs/helpers');
+const isValidPath = require('is-valid-path');
+
+const {argv} = yargs(hideBin(process.argv));
 
 meow(`
 	Usage
@@ -16,11 +22,21 @@ const source = `
 @tailwind utilities;
 `;
 
-postcss([tailwind])
+function checkArg(arg) {
+	return arg && isValidPath(arg);
+}
+
+postcss([checkArg(argv.i) ? tailwind(argv.i) : tailwind])
 	.process(source, {from: undefined})
 	.then(({css}) => {
+		if (checkArg(argv.o)) {
+			fs.promises.mkdir(path.dirname(argv.o), {recursive: true});
+		}
 		const styles = build(css);
-		fs.writeFileSync('styles.json', JSON.stringify(styles, null, '\t'));
+		fs.writeFileSync(
+			checkArg(argv.o) ? argv.o : 'styles.json',
+			JSON.stringify(styles, null, '\t')
+		);
 	})
 	.catch(error => {
 		console.error('> Error occurred while generating styles');

--- a/package.json
+++ b/package.json
@@ -35,9 +35,11 @@
 	"dependencies": {
 		"css": "^2.2.4",
 		"css-to-react-native": "^3.0.0",
+		"is-valid-path": "^0.1.1",
 		"match-all": "^1.2.6",
 		"meow": "^7.0.1",
-		"postcss": "^8.1.14"
+		"postcss": "^8.1.14",
+		"yargs": "^16.2.0"
 	},
 	"devDependencies": {
 		"@ava/babel": "^1.0.1",

--- a/readme.md
+++ b/readme.md
@@ -138,6 +138,12 @@ Add this file to your version control system, because it's going to be needed wh
 $ npx create-tailwind-rn
 ```
 
+You can specify a path to your tailwind configuration with the `-i` flag, as well as the filename for your generated json file with the `-o` flag.
+
+```
+$ npx create-tailwind-rn -i path/to/tailwind.config.js -o styles.json
+```
+
 #### 3. Create a custom `tailwind()` function
 
 Use `create()` function to generate the same `tailwind()` and `getColor()` functions, but with your custom styles applied.


### PR DESCRIPTION
### What: 

This PR adds support for a custom tailwind configuration file path, as well as a custom styles.json path.

### How:

Simple implementation of the [yargs](https://github.com/yargs/yargs) library. The user can provide arguments to  `-i` (for input) and/or -o (output filename). The behaviour remains unchanged when no arguments are passed (takes ./tailwind.config.js  and outputs ./styles.json file)