### PR TITLE
Support relative lineHeight utilities

### DIFF
--- a/build.js
+++ b/build.js
@@ -6,14 +6,6 @@ const remToPx = value => `${Number.parseFloat(value) * 16}px`;
 
 const getStyles = rule => {
 	const styles = rule.declarations
-		.filter(({property, value}) => {
-			// Skip line-height utilities without units
-			if (property === 'line-height' && !value.endsWith('rem')) {
-				return false;
-			}
-
-			return true;
-		})
 		.map(({property, value}) => {
 			if (value.endsWith('rem')) {
 				return [property, remToPx(value)];
@@ -130,10 +122,6 @@ const isUtilitySupported = (utility, rule) => {
 		}
 
 		if (property === 'position' && !['absolute', 'relative'].includes(value)) {
-			return false;
-		}
-
-		if (property === 'line-height' && !value.endsWith('rem')) {
 			return false;
 		}
 

--- a/index.js
+++ b/index.js
@@ -37,6 +37,33 @@ const addFontVariant = (style, classNames) => {
 // in em unit, that's why it requires a font size to be set too
 const FONT_SIZE_REGEX = /text-(xs|sm|base|lg|xl|2xl|3xl|4xl|5xl|6xl)/;
 const LETTER_SPACING_REGEX = /(tracking-[a-z]+)/;
+const LINE_HEIGHT_REGEX = /(leading-(.+))/;
+
+const addLineHeight = (tailwindStyles, style, classNames) => {
+	const lineHeightMatches = LINE_HEIGHT_REGEX.exec(classNames);
+
+	if (!lineHeightMatches) {
+		return;
+	}
+
+	const lineHeightClass = lineHeightMatches[0];
+	const lineHeightModifier = Number(lineHeightClass.split('-')[1]);
+	const {lineHeight} = tailwindStyles[lineHeightClass];
+
+	if (!Number.isNaN(lineHeightModifier)) {
+		style.lineHeight = lineHeight;
+
+		return;
+	}
+
+	if (!style.fontSize) {
+		throw new Error(
+			"Font size is required when applying letter spacing, e.g. 'text-lg leading-loose'" // eslint-disable-line quotes
+		);
+	}
+
+	style.lineHeight = Number.parseFloat(lineHeight) * style.fontSize;
+};
 
 const addLetterSpacing = (tailwindStyles, style, classNames) => {
 	const letterSpacingMatches = LETTER_SPACING_REGEX.exec(classNames);
@@ -79,7 +106,8 @@ const create = tailwindStyles => {
 			.replace(/\s+/g, ' ')
 			.trim()
 			.split(' ')
-			.filter(className => !className.startsWith('tracking-'));
+			.filter(className => !className.startsWith('tracking-'))
+			.filter(className => !className.startsWith('leading-'));
 
 		for (const className of separateClassNames) {
 			if (tailwindStyles[className]) {
@@ -88,6 +116,8 @@ const create = tailwindStyles => {
 				console.warn(`Unsupported Tailwind class: "${className}"`);
 			}
 		}
+
+		addLineHeight(tailwindStyles, style, classNames);
 
 		return useVariables(style);
 	};

--- a/test.js
+++ b/test.js
@@ -107,6 +107,18 @@ test('support font-variant-numeric', t => {
 	);
 });
 
+test('support line height', t => {
+	t.deepEqual(tailwind('text-base leading-loose'), {
+		fontSize: 16,
+		lineHeight: 32
+	});
+
+	t.deepEqual(tailwind('text-base leading-5'), {
+		fontSize: 16,
+		lineHeight: 20
+	});
+});
+
 test('support letter spacing', t => {
 	t.deepEqual(tailwind('text-base tracking-tighter'), {
 		fontSize: 16,


### PR DESCRIPTION
Add support for the relative line-height utilities such as `leading-relaxed` etc.

Uses the same pattern as the tracking code.

The `addLineHeights` was moved to the bottom of the function since the default font variants all have a default `lineHeight: 24` in `styles.json`.

By having the `addLineHeight` at the bottom also removes the need for the font size regex check.