### PR TITLE
[Tailwind JIT Support] Find all matches when cleaning rule selector name

### DIFF
--- a/build.js
+++ b/build.js
@@ -159,7 +159,7 @@ module.exports = source => {
 	for (const rule of stylesheet.rules) {
 		if (rule.type === 'rule') {
 			for (const selector of rule.selectors) {
-				const utility = selector.replace(/^\./, '').replace('\\', '');
+				const utility = selector.replace(/^\./g, '').replace(/\\/g, '');
 
 				if (isUtilitySupported(utility, rule)) {
 					styles[utility] = getStyles(rule);


### PR DESCRIPTION
This allows tailwind-rn to play nicely with JIT mode.

```js
tailwind("text-[3.75rem]")
```

**Before fix**

```json
"text-[3\\.75rem\\]": {
  "fontSize": 60
},
```

**After fix**

```json
"text-[3.75rem]": {
  "fontSize": 60
},
```