### PR TITLE
cli params add: allow to change rem size (in pixel) and output file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 yarn.lock
 styles.json
+.idea

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,15 +1,11 @@
 #!/usr/bin/env node
 'use strict';
 const fs = require('fs');
-const meow = require('meow');
 const postcss = require('postcss');
 const tailwind = require('tailwindcss');
-const build = require('./build');
+const build = require('../utils/build');
 
-meow(`
-	Usage
-	  $ create-tailwind-rn
-`);
+const flags = require('../utils/cli-parse')
 
 const source = `
 @tailwind components;
@@ -19,8 +15,8 @@ const source = `
 postcss([tailwind])
 	.process(source, {from: undefined})
 	.then(({css}) => {
-		const styles = build(css);
-		fs.writeFileSync('styles.json', JSON.stringify(styles, null, '\t'));
+		const styles = build(css, flags.rem);
+    fs.writeFileSync(flags.outFile, JSON.stringify(styles, null, '\t'));
 	})
 	.catch(error => {
 		console.error('> Error occurred while generating styles');

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"node": ">=10"
 	},
 	"scripts": {
-		"build": "node cli",
+		"build": "node bin/cli",
 		"prepare": "npm run build",
 		"test": "xo && tsd && ava"
 	},

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"url": "https://vadimdemedes.com"
 	},
 	"bin": {
-		"create-tailwind-rn": "cli.js"
+		"create-tailwind-rn": "bin/cli.js"
 	},
 	"engines": {
 		"node": ">=10"
@@ -21,8 +21,8 @@
 		"test": "xo && tsd && ava"
 	},
 	"files": [
-		"build.js",
-		"cli.js",
+	  "utils/build.js",
+	  "bin/cli.js",
 		"index.js",
 		"index.d.ts",
 		"styles.json"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 	},
 	"files": [
 	  "utils/build.js",
+	  "utils/cli-parse.js",
 	  "bin/cli.js",
 		"index.js",
 		"index.d.ts",

--- a/readme.md
+++ b/readme.md
@@ -140,6 +140,7 @@ Add this file to your version control system, because it's going to be needed wh
 ```
 $ npx create-tailwind-rn
 ```
+run `npx create-tailwind-rn --help` for options
 
 #### 3. Create a custom `tailwind()` function
 

--- a/utils/build.js
+++ b/utils/build.js
@@ -2,9 +2,9 @@
 const css = require('css');
 const cssToReactNative = require('css-to-react-native').default;
 
-const remToPx = value => `${Number.parseFloat(value) * 16}px`;
+const remToPx = (value, remSize) => `${Number.parseFloat(value) * remSize}px`;
 
-const getStyles = rule => {
+const getStyles = (rule, remSize = 16) => {
 	const styles = rule.declarations
 		.filter(({property, value}) => {
 			// Skip line-height utilities without units
@@ -16,7 +16,7 @@ const getStyles = rule => {
 		})
 		.map(({property, value}) => {
 			if (value.endsWith('rem')) {
-				return [property, remToPx(value)];
+				return [property, remToPx(value, remSize)];
 			}
 
 			return [property, value];
@@ -150,7 +150,7 @@ const isUtilitySupported = (utility, rule) => {
 	return true;
 };
 
-module.exports = source => {
+module.exports = (source, remSize = 16) => {
 	const {stylesheet} = css.parse(source);
 
 	// Mapping of Tailwind class names to React Native styles
@@ -162,7 +162,7 @@ module.exports = source => {
 				const utility = selector.replace(/^\./, '').replace('\\', '');
 
 				if (isUtilitySupported(utility, rule)) {
-					styles[utility] = getStyles(rule);
+					styles[utility] = getStyles(rule, remSize);
 				}
 			}
 		}

--- a/utils/cli-parse.js
+++ b/utils/cli-parse.js
@@ -1,0 +1,34 @@
+const meow = require('meow');
+const path = require('path');
+
+const cli = meow(`
+  Usage
+    $ create-tailwind-rn
+
+  Options
+    --rem, -r        change rem size in pixel (default: 16)
+    --outFile, -o    change the path of the output file (default: **executing-folder**/styles.json)
+`, {
+  flags: {
+    rem: {
+      type: 'number',
+      alias: 'r',
+      default: 16
+    },
+    outFile: {
+      type: 'string',
+      alias: 'o',
+      default: process.cwd() + '/styles.json',
+    }
+  }
+});
+
+const flags = {...cli.flags}
+if (flags.outFile.endsWith('/')) {
+  flags.outFile += 'styles.json'
+} else if (!flags.outFile.endsWith('.json')) {
+  flags.outFile += '.json'
+}
+flags.outFile = path.resolve(process.cwd(), flags.outFile)
+
+module.exports = flags


### PR DESCRIPTION
You can do sth likes 
`npx create-tailwind-rn -r 12 -o styles-12.json`
`npx create-tailwind-rn -r 16 -o styles-16.json`

```js
// tailwind.js
import { create } from 'tailwind-rn'
import { Dimensions } from 'react-native'

const { height, scale } = Dimensions.get('window')

const remSize = height * scale <= 1366 ? 12 : 16
const styles = {
  12: require('./styles-12.json'),
  16: require('./styles-16.json'),
}

const { tailwind: oTailwind, getColor } = create(styles[remSize])
const tailwind = (...classes) => oTailwind(classes.join(' '))
export {
  tailwind,
  getColor,
  remSize,
}
```