### PR TITLE
Add support to work with elevation class

### DIFF
--- a/outbox.json
+++ b/outbox.json
@@ -1,0 +1,41 @@
+{
+  "elevation-none": {
+    "elevation": 0
+  },
+  "elevation-20": {
+    "elevation": 2
+  },
+  "elevation-40": {
+    "elevation": 4
+  },
+  "elevation-60": {
+    "elevation": 6
+  },
+  "elevation-80": {
+    "elevation": 8
+  },
+  "elevation-100": {
+    "elevation": 10
+  },
+  "elevation-sm": {
+    "elevation": 12
+  },
+  "elevation-md": {
+    "elevation": 14
+  },
+  "elevation-lg": {
+    "elevation": 16
+  },
+  "elevation-xl": {
+    "elevation": 18
+  },
+  "elevation-2xl": {
+    "elevation": 20
+  },
+  "elevation-3xl": {
+    "elevation": 22
+  },
+  "elevation-4xl": {
+    "elevation": 24
+  }
+}

--- a/readme.md
+++ b/readme.md
@@ -113,6 +113,7 @@ tailwind('pt-12 items-center');
 
 ### Effects
 
+- [Elevation](#out-the-box)
 - [Opacity](https://tailwindcss.com/docs/opacity)
 
 ### Interactivity
@@ -187,6 +188,32 @@ import {tailwind} from 'tailwind';
 Type: `string[]`
 
 Array of Tailwind CSS classes you want to generate styles for.
+
+
+### Out the box
+
+Some class were also added to support some native styling. 
+
+##### Elevation
+
+| Class       			| Properties |
+| ----------------- | ---------- |
+| "elevation-none"  | 0     		 |
+| elevation-20   	  | 2      		 |
+| elevation-40   		| 4     		 |
+| elevation-60   		| 6     		 |
+| elevation-80      | 8     		 |
+| elevation-100   	| 10    		 |
+| elevation-sm   		| 12    		 |
+| elevation-md   		| 14    		 |
+| elevation-lg   		| 16    		 |
+| elevation-xl   		| 18    		 |
+| elevation-2xl   	| 20    		 |
+| elevation-3xl   	| 22    		 |
+| elevation-4xl   	| 24    		 |
+
+
+
 
 ### getColor(color)
 

--- a/test.js
+++ b/test.js
@@ -107,6 +107,60 @@ test('support font-variant-numeric', t => {
 	);
 });
 
+test('Support elevation test', t => {
+	t.deepEqual(tailwind('elevation-none'), {
+		elevation: 0
+	});
+
+	t.deepEqual(tailwind('elevation-20'), {
+		elevation: 2
+	});
+
+	t.deepEqual(tailwind('elevation-40'), {
+		elevation: 4
+	});
+
+	t.deepEqual(tailwind('elevation-60'), {
+		elevation: 6
+	});
+
+	t.deepEqual(tailwind('elevation-80'), {
+		elevation: 8
+	});
+
+	t.deepEqual(tailwind('elevation-100'), {
+		elevation: 10
+	});
+
+	t.deepEqual(tailwind('elevation-sm'), {
+		elevation: 12
+	});
+
+	t.deepEqual(tailwind('elevation-md'), {
+		elevation: 14
+	});
+
+	t.deepEqual(tailwind('elevation-lg'), {
+		elevation: 16
+	});
+
+	t.deepEqual(tailwind('elevation-xl'), {
+		elevation: 18
+	});
+
+	t.deepEqual(tailwind('elevation-2xl'), {
+		elevation: 20
+	});
+
+	t.deepEqual(tailwind('elevation-3xl'), {
+		elevation: 22
+	});
+
+	t.deepEqual(tailwind('elevation-4xl'), {
+		elevation: 24
+	});
+});
+
 test('support letter spacing', t => {
 	t.deepEqual(tailwind('text-base tracking-tighter'), {
 		fontSize: 16,


### PR DESCRIPTION
## About

At February, I worked in a React Native project and decided to use Tailwind on my project. So, as common Material-UI practice, I created a floating action button component that could did any action. But I realized that the `elevation` class doesn't belongs to Tailwind and not exist on tailwind-rn.  So, I opened a new issue to discuss it, until a guy suggested me to collaborate with this support. I started to think in a solution and coding it. To make te scope understand that "there are" elevation class on Tailwind, I created a `outbox.json` file (I believe that combine with the idea to take non-existents class and define in a json, instead of dirty the code) that store elevation options. The `addElevation` function make a regex match and use it to fetch the binded class and recovery a value. I really hope I can help you guys to improve the project even more 😄 🚀

## Steps
- [x] Write tests
- [x] Develope a solution for the problem
- [x] Document it on Readme

## Additional
* [Mentioned issue](https://github.com/vadimdemedes/tailwind-rn/issues/66)
* [About elevation class](https://reactnative.dev/docs/view-style-props#elevation-android)