### PR TITLE
Purge function will conflict with getColor

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,10 +92,10 @@ const create = tailwindStyles => {
 		return useVariables(style);
 	};
 
-	// Pass the name of a color (e.g. "blue-500") and receive a color value (e.g. "#4399e1"),
-	// or a color and opacity (e.g. "black opacity-50") and get a color with opacity (e.g. "rgba(0,0,0,0.5)")
+	// Pass the name of a color (e.g. "bg-blue-500") and receive a color value (e.g. "#4399e1"),
+	// or a color and opacity (e.g. "bg-black bg-opacity-50") and get a color with opacity (e.g. "rgba(0,0,0,0.5)")
 	const getColor = name => {
-		const style = tailwind(name.split(' ').map(className => `bg-${className}`).join(' '));
+		const style = tailwind(name);
 		return style.backgroundColor;
 	};
 

--- a/readme.md
+++ b/readme.md
@@ -195,7 +195,7 @@ Get color value from Tailwind CSS color name.
 ```js
 import {getColor} from 'tailwind-rn';
 
-getColor('blue-500');
+getColor('bg-blue-500');
 //=> '#ebf8ff'
 ```
 
@@ -204,7 +204,7 @@ To get a color with opacity:
 ```js
 import {getColor} from 'tailwind-rn';
 
-getColor('blue-500 opacity-50');
+getColor('bg-blue-500 bg-opacity-50');
 //=> 'rgba(66, 153, 225, 0.5)'
 ```
 

--- a/test.js
+++ b/test.js
@@ -45,11 +45,11 @@ test('ignore non-string values when transforming CSS variables', t => {
 });
 
 test('get color value', t => {
-	t.is(getColor('blue-500'), 'rgba(59, 130, 246, 1)');
+	t.is(getColor('bg-blue-500'), 'rgba(59, 130, 246, 1)');
 });
 
 test('get color with opacity value', t => {
-	t.is(getColor('blue-500 opacity-50'), 'rgba(59, 130, 246, 0.5)');
+	t.is(getColor('bg-blue-500 bg-opacity-50'), 'rgba(59, 130, 246, 0.5)');
 });
 
 test('ignore no value param', t => {


### PR DESCRIPTION
### Issue

When I use `getColor` in my code and have `purge` turned on

```javascript
// tailwind.config.js
module.exports = {
    purge: {
        enabled: true,
        content: ['../../src/**/*.ts', '../../src/**/*.tsx']
    },
    // ...
}
```

Since tailwind does not support border colors by default, so I had to go the extra mile and use the method provided by RN.

At this point, I need to use `getColor`.

```javascript
// PageA.styles.ts
const styles = StyleSheet.create({
    container: {
        ...tailwind('w-11 h-11 bg-black text-white'),
        borderTopColor: getColor("blue-500")
    }
})
```

But after I used `purge`, tailwind scans for CSS classes that are already in use by default, so `blue-500` is not recognized and is not packed into `styles.json`. 

That's the problem.

### Solutions

`getColor` can be declared using tailwind's own


```javascript
// PageA.styles.ts
const styles = StyleSheet.create({
    container: {
        ...tailwind('w-11 h-11 bg-black text-white'),
        borderTopColor: getColor("bg-blue-500 bg-opacity-50")
    }
})
```

So the getColor function will be like

```javascript
// Pass the name of a color (e.g. "bg-blue-500") and receive a color value (e.g. "#4399e1"),
// or a color and opacity (e.g. "bg-black bg-opacity-50") and get a color with opacity (e.g. "rgba(0,0,0,0.5)")
const getColor = name => {
    const style = tailwind(name);
    return style.backgroundColor;
};
```