### PR TITLE
Fix race condition during file watching

### DIFF
--- a/source/cli.ts
+++ b/source/cli.ts
@@ -57,7 +57,7 @@ const build = () => {
 };
 
 if (watch) {
-	chokidar.watch(input, { awaitWriteFinish: true }).on('all', build);
+	chokidar.watch(input, {awaitWriteFinish: true}).on('all', build);
 } else {
 	build();
 }

--- a/source/cli.ts
+++ b/source/cli.ts
@@ -57,7 +57,7 @@ const build = () => {
 };
 
 if (watch) {
-	chokidar.watch(input).on('all', build);
+	chokidar.watch(input, { awaitWriteFinish: true }).on('all', build);
 } else {
 	build();
 }


### PR DESCRIPTION
Currently, there is a race happening between `tailwind-rn` `watch` command and `tailwindcss` generation.
If the `input` file provided to `tailwind-rn` grows, it happens, that `tailwind-rn` will start building the JSON-File before the input file is entirely written. This leads to an empty JSON File described here: https://github.com/vadimdemedes/tailwind-rn/issues/130.

To resolve this issue, the `awaitWriteFinish` option is set to true. This waits for the input file to stay constant in file size before triggering the build process.

> awaitWriteFinish (default: false). By default, the add event will fire when a file first appears on disk, before the entire file has been written. Furthermore, in some cases some change events will be emitted while the file is being written. In some cases, especially when watching for large files there will be a need to wait for the write operation to finish before responding to a file creation or modification. Setting awaitWriteFinish to true (or a truthy value) will poll file size, holding its add and change events until the size does not change for a configurable amount of time. The appropriate duration setting is heavily dependent on the OS and hardware. For accurate detection this parameter should be relatively high, making file watching much less responsive. Use with caution.
options.awaitWriteFinish can be set to an object in order to adjust timing params:
awaitWriteFinish.stabilityThreshold (default: 2000). Amount of time in milliseconds for a file size to remain constant before emitting its event.
awaitWriteFinish.pollInterval (default: 100). File size polling interval, in milliseconds.

Ref: https://github.com/paulmillr/chokidar#performance

The timing can be optimized, I think. But it works well, and the build process of the tailwind.json file is not a time-critical operation. I rather wait for 2000 milliseconds than having a single race condition occurrence.