### PR TITLE
React 18 "children"

### DIFF
--- a/source/tailwind-provider.tsx
+++ b/source/tailwind-provider.tsx
@@ -10,8 +10,9 @@ import create from './create';
 import {Utilities} from './types';
 
 interface Props {
-	utilities: Utilities;
+	children: React.ReactNode;
 	colorScheme?: ColorSchemeName;
+	utilities: Utilities;
 }
 
 const TailwindProvider: React.FC<Props> = ({


### PR DESCRIPTION
# Overview

This PR explicitly adds `children` to the provider props. Hard to find the right document for reference but [this one](https://solverfox.dev/writing/no-implicit-children/) is pretty great.

- https://github.com/vadimdemedes/tailwind-rn/issues/181
