### PR TITLE
feat: web support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 dist
 node_modules
 yarn.lock
+
+*.swp
+*.swo

--- a/source/use-tailwind.native.ts
+++ b/source/use-tailwind.native.ts
@@ -1,0 +1,8 @@
+const useTailwind = () => {
+  return (str: string) => ({
+    $$css: true,
+    [str]: str
+  })
+}
+
+export default useTailwind

--- a/source/use-tailwind.native.ts
+++ b/source/use-tailwind.native.ts
@@ -1,8 +1,8 @@
-const useTailwind = () => {
-  return (str: string) => ({
-    $$css: true,
-    [str]: str
-  })
-}
+import {useContext} from 'react';
+import TailwindContext from './tailwind-context';
 
-export default useTailwind
+const useTailwind = () => {
+	return useContext(TailwindContext);
+};
+
+export default useTailwind;

--- a/source/use-tailwind.ts
+++ b/source/use-tailwind.ts
@@ -1,8 +1,8 @@
-import {useContext} from 'react';
-import TailwindContext from './tailwind-context';
-
 const useTailwind = () => {
-	return useContext(TailwindContext);
-};
+  return (str: string) => ({
+    $$css: true,
+    [str]: str
+  })
+}
 
-export default useTailwind;
+export default useTailwind


### PR DESCRIPTION
I managed to make this work for web in an easy way, which doesn't require an impact on native

Say your web app already uses tailwind.
```jsx

function Page() {
  return <div className="flex-1">
    <SharedComponent />
  </div>
)
```

And you would like to share a component between your RN app and ReactJS app:
```jsx
import {View} from 'react-native-web';
import {useTailwind) from 'tailwind-rn'

function SharedComponent() {
 const tw = useTailwind();
  return <View style={tw('bg-red-500 w-full h-16')} />
} 
```
For native, nothing changes, but for web it pass the tailwind CSS classnames to RNW (which requires a `$$css` flag)

I have a babel plugin which makes it work for SVG imported with react-native-svg-transformer plugin, but already wanted to know your opinion on this?